### PR TITLE
fix #4 - conflicting use of /app/config/gpg

### DIFF
--- a/argocd-repo-server-wrapper
+++ b/argocd-repo-server-wrapper
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-GPG_PRIVATE_KEY_FILE='/app/config/gpg/privkey.asc'
+GPG_PRIVATE_KEY_FILE='/app/config/gpg2/privkey.asc'
 
 if [ -f "${GPG_PRIVATE_KEY_FILE}" ]
 then


### PR DESCRIPTION
argo-cd image now uses /app/config/gpg for doing Git commit validation, which causes a conflict of the directory used to import a SOPS gpg key.